### PR TITLE
Fix env var naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,3 +311,16 @@ This directory contains classes related to managing products. It includes `Produ
 #### reasoning_engines ####
 
 This directory contains logic and interfaces for reasoning engines, including `GPTModels.py`.
+
+## Environment Variables ##
+
+The application expects several API keys to be available through environment
+variables:
+
+- `SERP_API_KEY`
+- `BROWSERLESS_API_KEY`
+- `OPENROUTER_API_KEY`
+
+Copy `example.env` and populate these values, then place the resulting file in a
+`vars/` directory at the project root. Keep the `vars/` directory unversioned so
+your credentials remain private.

--- a/example.env
+++ b/example.env
@@ -1,4 +1,3 @@
-OPEN_API_KEY = "xxx"
 SERP_API_KEY = "xxx"
 BROWSERLESS_API_KEY = "xxx"
 OPENROUTER_API_KEY = "xxx"


### PR DESCRIPTION
## Summary
- drop unused `OPEN_API_KEY` variable
- list all required API keys in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503a9f40cc832586d8aaf983c60ac0